### PR TITLE
Add test for makeDraggable pointer events handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fadi",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/makeDraggable.test.js
+++ b/tests/makeDraggable.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const path = require('node:path');
+
+class Element extends EventTarget {
+  constructor(id) {
+    super();
+    this.id = id;
+    this.style = {};
+    this.iframe = null;
+  }
+  querySelector(sel) {
+    if (sel === 'iframe') return this.iframe;
+    return null;
+  }
+  getBoundingClientRect() {
+    return { top: 0, left: 0, width: 100, height: 100 };
+  }
+  closest() {
+    return null;
+  }
+}
+
+class MouseEvent extends Event {
+  constructor(type, opts = {}) {
+    super(type);
+    this.button = opts.button || 0;
+    this.clientX = opts.clientX || 0;
+    this.clientY = opts.clientY || 0;
+  }
+  preventDefault() {}
+}
+
+test('iframe pointerEvents toggled during drag', () => {
+  const window = new EventTarget();
+  const document = {};
+  const el = new Element('pdf-pane');
+  const iframe = new Element('iframe');
+  el.iframe = iframe;
+
+  const code = fs.readFileSync(path.join(__dirname, '..', 'Quiz'), 'utf8');
+  const start = code.indexOf('function ensureFixed');
+  const end = code.indexOf('// Enable dragging');
+  const snippet = code.substring(start, end);
+
+  const context = { window, document };
+  vm.createContext(context);
+  vm.runInContext(snippet, context);
+  const makeDraggable = context.makeDraggable;
+
+  makeDraggable(el);
+
+  el.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 0, clientY: 0 }));
+  assert.strictEqual(iframe.style.pointerEvents, 'none');
+
+  window.dispatchEvent(new MouseEvent('mouseup'));
+  assert.strictEqual(iframe.style.pointerEvents, '');
+});


### PR DESCRIPTION
## Summary
- add Node test for makeDraggable to verify iframe pointer events toggled on drag
- configure package script to run node's built-in test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897a83af04083328874183c99ab68f3