### PR TITLE
Ensure fixed positioning always retains element height

### DIFF
--- a/Quiz
+++ b/Quiz
@@ -94,10 +94,8 @@ body.arrange-mode .drag-handle{display:block}
     el.style.top = Math.max(8, r.top) + 'px';
     el.style.left = Math.max(8, r.left) + 'px';
     el.style.width = r.width + 'px';
-    // Keep current height to avoid content jumps; pdf pane needs a height
-    if(el.id === 'pdf-pane'){
-      el.style.height = r.height + 'px';
-    }
+    // Keep current height to avoid content jumps
+    el.style.height = r.height + 'px';
   }
   function unfix(el){
     el.style.position = '';


### PR DESCRIPTION
## Summary
- Remove `pdf-pane` check so `ensureFixed` sets height for all elements
- Confirm `unfix` continues to clear height for normal layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ae23040c8332bad85ce148627cd5